### PR TITLE
Fix modal animations

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2202,7 +2202,6 @@ ul.pagination.loading .link--active {
   position: fixed;
   background-color: #FFF;
   visibility: hidden;
-  animation: hide_modal 125ms linear;
 }
 
 .modal + .overlay {
@@ -2213,7 +2212,6 @@ ul.pagination.loading .link--active {
   right: 0;
   z-index: 5;
   visibility: hidden;
-  animation: hide_modal 125ms linear;
   background-color: rgba(0, 0, 0, 0.25);
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -124,7 +124,6 @@ hr {
   from {
     opacity: 1;
     display: initial;
-    visibility: visible;
   }
   to {
     opacity: 0;
@@ -149,27 +148,22 @@ hr {
   }
 }
 @keyframes phase_to_center {
-  0% {
+  from {
     opacity: 0;
-    visibility: visible;
     transform: translateX(0%);
   }
-  100% {
+  to {
     opacity: 1;
     transform: translateX(-50%);
   }
 }
 @keyframes phase_to_left {
-  0% {
+  from {
     opacity: 1;
-    visibility: visible;
   }
-  99% {
+  to {
     opacity: 0;
     transform: translateX(-100%);
-  }
-  100% {
-    visibility: hidden;
   }
 }
 html {

--- a/css/style.css
+++ b/css/style.css
@@ -2225,6 +2225,16 @@ ul.pagination.loading .link--active {
   animation: show_modal 125ms linear;
 }
 
+.modal.hide {
+  visibility: inherit;
+  animation: hide_modal 125ms linear;
+}
+
+.modal.hide + .overlay {
+  visibility: inherit;
+  animation: hide_modal 125ms linear;
+}
+
 .toast {
   box-sizing: border-box;
   -webkit-box-sizing: border-box;

--- a/js/classes/modal.js
+++ b/js/classes/modal.js
@@ -17,7 +17,14 @@ export class Modal {
     }
     // Close Method.
     close() {
-        this.node.classList.remove('visible');
+        const handler = (e) => {
+            this.node.classList.remove('visible');
+            this.node.classList.remove('hide');
+            this.node.removeEventListener('animationend', handler);
+        };
+
+        this.node.addEventListener('animationend', handler);
+        this.node.classList.add('hide');
     }
 
     // Upload Information To The Server.

--- a/sass/2. Tools/_animations.scss
+++ b/sass/2. Tools/_animations.scss
@@ -13,7 +13,6 @@
     from {
         opacity: 1;
         display: initial;
-        visibility: visible;
     }
 
     to {
@@ -43,30 +42,24 @@
 
 
 @keyframes phase_to_center {
-    0% {
+    from {
         opacity: 0;
-        visibility: visible;
         transform: translateX(-0%);
     }
 
-    100% {
+    to {
         opacity: 1;
         transform: translateX(-50%);
     }
 }
 
 @keyframes phase_to_left {
-    0% {
+    from {
         opacity: 1;
-        visibility: visible;
     }
 
-    99% {
+    to {
         opacity: 0;
         transform: translateX(-100%);
-    }
-
-    100% {
-        visibility: hidden;
     }
 }

--- a/sass/4. Components/_modals.scss
+++ b/sass/4. Components/_modals.scss
@@ -15,7 +15,6 @@
 
     background-color: $classic-w;
     visibility: hidden;
-    animation: hide_modal 125ms linear;
 }
 
 .modal + .overlay {
@@ -27,8 +26,6 @@
     z-index: 5;
 
     visibility: hidden;
-    
-    animation: hide_modal 125ms linear;
     
     background-color: rgba(black, 0.25);
 }

--- a/sass/4. Components/_modals.scss
+++ b/sass/4. Components/_modals.scss
@@ -39,3 +39,16 @@
     visibility: visible;
     animation: show_modal 125ms linear;
 }
+
+.modal.hide {
+    visibility: inherit;
+    animation: hide_modal 125ms linear;
+
+}
+
+.modal.hide + .overlay {
+    visibility: inherit;
+    animation: hide_modal 125ms linear;
+
+}
+


### PR DESCRIPTION
This PR applies the following improvements:
- Fixes `#New-Account-Modal` glitchy behaviour displayed by one of its children every time the page load.
- Creates a new CSS class `.hide` for use when fading out any modal component
- Enhances the `Modal` method `close()`. 