### PR TITLE
Fix Multiple Column Update of Accounts Records

### DIFF
--- a/php/fun/accounts.php
+++ b/php/fun/accounts.php
@@ -20,6 +20,15 @@ $conn = new mysqli('localhost', 'root', '', 'test');
 //     15 => 'F',
 // ];
 
+$column_dictionary = array(
+    '__WBEGINS' => 'WARRANTY_BEGINS',
+    '__WENDS' => 'WARRANTY_ENDS',
+    '__NICKNAME' => 'ACCOUNT_NICK',
+    '__PASSWORD' => 'ACCOUNT_PASS',
+    '__PRICE' => 'PRICE_PAID',
+    '__AVAILABLE_ACCOUNTS' => 'N_AVAILABLE'
+);
+
 function create_toast(string $message) {
     return <<<TOAST
                 <div class="toast"> 

--- a/php/fun/accounts.php
+++ b/php/fun/accounts.php
@@ -92,4 +92,43 @@ function new_id() {
     
 }
 
+function createMultipleColumnUpdateString(array $POST) {
+  global $column_dictionary;
+  $update_str = "";
+  $updated_columns = array();
+
+  foreach($POST as $column => $value) {
+    $front_comma = (sizeof($updated_columns) > 0) ? "," : "";
+
+    switch($column) {
+      case "__PRICE":
+        $update_str .= "$front_comma `{$column_dictionary["__PRICE"]}` = {$_POST["__PRICE"]}";
+        array_push($updated_columns, $_POST["__PRICE"]);
+        break;
+      case "__AVAILABLE_ACCOUNTS":
+        $update_str .= "$front_comma `{$column_dictionary["__AVAILABLE_ACCOUNTS"]}` = {$_POST["__AVAILABLE_ACCOUNTS"]}";
+        array_push($updated_columns, $_POST["__AVAILABLE_ACCOUNTS"]);
+        break;
+      case "__PASSWORD":
+        $update_str .= "$front_comma `{$column_dictionary["__PASSWORD"]}` = '{$_POST["__PASSWORD"]}'";
+        array_push($updated_columns, $_POST["__PASSWORD"]);
+        break;
+      case "__WBEGINS":
+        $update_str .= "$front_comma `{$column_dictionary["__WBEGINS"]}` = '{$_POST["__WBEGINS"]}'";
+        array_push($updated_columns, $_POST["__WBEGINS"]);
+        break;
+      case "__WENDS":
+        $update_str .= "$front_comma `{$column_dictionary["__WENDS"]}` = '{$_POST["__WENDS"]}'";
+        array_push($updated_columns, $_POST["__WENDS"]);
+        break;
+
+      default:
+        break;
+    }
+
+  }
+
+  return $update_str;
+}
+
 ?>

--- a/php/hub.php
+++ b/php/hub.php
@@ -516,6 +516,7 @@ if( isset($_POST['__PULL']) && isset($_POST['__TOTAL_MESSAGES']) && isset($_POST
 // Update Variable Length Columns of a Given Account..
 if( isset($_POST['__PUT']) && isset($_POST['__ACCOUNT']) ) {
     $account_id = clean_txt($_POST['__ACCOUNT_ID']);
+    $update_str = createMultipleColumnUpdateString($_POST);
 
     $update_account_query = "UPDATE `$__ACCOUNTS` 
                              SET $updated_columns 

--- a/php/hub.php
+++ b/php/hub.php
@@ -515,23 +515,7 @@ if( isset($_POST['__PULL']) && isset($_POST['__TOTAL_MESSAGES']) && isset($_POST
 //
 // Update Variable Length Columns of a Given Account..
 if( isset($_POST['__PUT']) && isset($_POST['__ACCOUNT']) ) {
-    $updated_columns = '';
-    $updated_columns_values = '';
     $account_id = clean_txt($_POST['__ACCOUNT_ID']);
-
-    foreach($_POST as $index => $value) 
-    {
-
-        if ( $index != '__PUT' && $index != '__ACCOUNT' && $index != '__ACCOUNT_ID' ) 
-        {
-            if ( $index == '__PRICE' || $index == '__AVAILABLE_ACCOUNTS' ) {
-                $updated_columns .= "`$dictionary[$index]` = $value ";
-            }
-            else {
-                $updated_columns .= "`$dictionary[$index]` = '$value' ";
-            }
-        }
-    }
 
     $update_account_query = "UPDATE `$__ACCOUNTS` 
                              SET $updated_columns 

--- a/php/hub.php
+++ b/php/hub.php
@@ -513,7 +513,7 @@ if( isset($_POST['__PULL']) && isset($_POST['__TOTAL_MESSAGES']) && isset($_POST
 
 // UPDATE : 
 //
-// Update Variable Length Columns..
+// Update Variable Length Columns of a Given Account..
 if( isset($_POST['__PUT']) && isset($_POST['__ACCOUNT']) ) {
     $updated_columns = '';
     $updated_columns_values = '';

--- a/php/hub.php
+++ b/php/hub.php
@@ -518,8 +518,8 @@ if( isset($_POST['__PUT']) && isset($_POST['__ACCOUNT']) ) {
     $account_id = clean_txt($_POST['__ACCOUNT_ID']);
     $update_str = createMultipleColumnUpdateString($_POST);
 
-    $update_account_query = "UPDATE `$__ACCOUNTS` 
-                             SET $updated_columns 
+    $update_account_query = "UPDATE `$__ACCOUNTS`
+                             SET $update_str
                              WHERE `ACCOUNT_ID` = '$account_id'";
 
     $results = $main_conn->query($update_account_query);


### PR DESCRIPTION
Fix multiple column update not working properly when more than one field over `<edit-account-modal>` custom element was modified and submitted. 

Previous method was deleted and a new function was introduced to `/fun/accounts.php`