### PR TITLE
Fix orphan accounts being created

### DIFF
--- a/js/classes/NewAccountModal.js
+++ b/js/classes/NewAccountModal.js
@@ -176,7 +176,7 @@ class NewAccountModal extends HTMLElement {
   makeRequestBody() {
     const formData = new FormData()
     formData.append("__FUN", "New Account")
-    formData.append("__WEBSITE", this.selectWebsiteNode.label)
+    formData.append("__WEBSITE", this.selectWebsiteNode.optionChosen.code)
     formData.append("__NICK", this.usernameInput.value)
     formData.append("__PASS", this.passwordInput.value)
     formData.append("__PRICE", this.priceInputNode.value)


### PR DESCRIPTION
This PR fixes the orphan accounts being created issue (#54). This refers to accounts being assigned the wrong _website_ value, thus provoking a _lost_ account that would never be listed over the accounts page.