### PR TITLE
Fix phase change

### DIFF
--- a/cypress/e2e/NewWebsiteModal.cy.js
+++ b/cypress/e2e/NewWebsiteModal.cy.js
@@ -37,7 +37,7 @@ describe("basic functionality", () => {
   it("prevents form submission when fields are invalid", () => {
     cy.get("new-website-modal").then(($modal) => {
       const modal = $modal[0]
-      const formSubmit = cy.stub(modal, "submit").as("formSubmitMethod")
+      const formSubmit = cy.stub(modal, "makeRequestBody").as("formSubmitMethod")
 
       modal.showSecondStage()
 

--- a/cypress/e2e/NewWebsiteModal.cy.js
+++ b/cypress/e2e/NewWebsiteModal.cy.js
@@ -34,7 +34,7 @@ describe("basic functionality", () => {
       .should("not.be.visible")
   })
 
-  it("prevents form submision when fields are invalid", () => {
+  it("prevents form submission when fields are invalid", () => {
     cy.get("new-website-modal").then(($modal) => {
       const modal = $modal[0]
       const formSubmit = cy.stub(modal, "submit").as("formSubmitMethod")

--- a/cypress/e2e/NewWebsiteModal.cy.js
+++ b/cypress/e2e/NewWebsiteModal.cy.js
@@ -51,7 +51,6 @@ describe("basic functionality", () => {
   it("shows second stage when next button is pressed", () => {
     cy.get("new-website-modal").then(($modal) => {
       const modal = $modal[0]
-      const formSubmit = cy.stub(modal, "submit").as("formSubmitMethod")
 
       cy.wrap($modal).shadow().find("button.next").should("exist")
       cy.wrap($modal).shadow().find("button.next").click()

--- a/js/classes/NewWebsiteModal.js
+++ b/js/classes/NewWebsiteModal.js
@@ -252,6 +252,7 @@ export class NewWebsiteModal extends HTMLElement {
   submit() {
     if (this.stage === 1) {
       this.showSecondStage()
+      return
     } else if (!this.validateModal()) {
       return
     }


### PR DESCRIPTION
This PR fixes issue #56. Now the form of `<new-website-modal>` custom element will not submit until all of the form fields are valid. Other changes are minor changes to some tests inside `NewWebsiteModal.cy.js`. Currently all of the tests pass.