### PR TITLE
Implement secured pages

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -12,6 +12,7 @@ DB_TB_MESSAGES=messages_table
 DB_TB_RECLAIMS=reclaims_table
 DB_TB_SALES=sales_table
 DB_TB_VENDORS=vendors_table
+DB_TB_USERS=users_table
 
 # Base Directory
 ROOT_DIR=/

--- a/php/accounts.php
+++ b/php/accounts.php
@@ -1,5 +1,12 @@
 <?php
+session_start();
+
 require_once(dirname(__FILE__) . '/resources.php');
+
+if (!isset($_SESSION['user'])) {
+    header('Location:' . $_ENV['ROOT_DIR'] . '/login' );
+}
+
 require_once(dirname(__FILE__) . '/_general.php');
 
 // # Important variables for single page accounts page..

--- a/php/header.php
+++ b/php/header.php
@@ -33,4 +33,5 @@
     ?>
     </ul>
     </div>
+    <a class="page-link" href="<?= $_ENV['ROOT_DIR'] . '/logout' ?>">Log Out</a>
 </header>

--- a/php/login.php
+++ b/php/login.php
@@ -1,0 +1,113 @@
+<?php
+session_start();
+
+if (isset($_SESSION['user'])) {
+  header("Location: accounts");
+}
+
+require_once(dirname(__FILE__) . '/resources.php');
+?>
+
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <base href="<?= $_ENV['PHP_ROOT_DIR'] ?>">
+  <title>Login Page | Fappu Admin</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../css/style.css">
+  <style>
+    html {
+      background-color: #FCFCFC;
+    }
+    header {
+      margin-top: 2rem;
+      margin-bottom: 3rem;
+    }
+
+    h1 {
+      font-size: 2rem;
+      text-align: center;
+      cursor: default;
+    }
+
+    h1 .em {
+      color: #B208FA;
+    }
+
+    div.error {
+      width: 300px;
+      margin: 8px auto;
+      padding: 10px 25px;
+      background-color: #B208FA;
+
+      font-family: 'Roboto Condensed Light';
+      font-size: 16px;
+
+      color: white;
+      text-align: center;
+      box-sizing: border-box;
+      box-shadow: 0 2px 6px -2px gray;
+    }
+
+    @media screen and (max-width: 1000px) {
+      main {
+        padding: 0
+      }
+    }
+
+    @media screen and (max-width: 800px) {
+      div.error {
+        width: 90%;
+      }
+
+      main form {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+
+      main form button {
+        width: fit-content;
+        flex: 0 0 auto;
+        align-self: flex-end;
+      }
+    }
+  </style>
+</head>
+
+<body>
+  <header>
+    <h1>Fappu<br><span class="em">Admin</span></h1>
+  </header>
+
+  <?php if (isset($_GET['error_banner'])): ?>
+    <div class="error">Wrong credentials</div>
+  <?php endif; ?>
+
+  <main>
+    <form action="<?= $_ENV['ROOT_DIR'] . '/v1/users' ?>" method="post">
+      <input type="text" class="LL" placeholder="username" autocomplete="true" name="Username" required>
+      <input type="password" class="LL" placeholder="password" autocomplete="false" name="Password" required>
+      <button class="button button small secondary" type="submit">Log In</button>
+    </form>
+  </main>
+
+  <footer>
+    <script>
+      let form = document.querySelector('form')
+      let button = document.querySelector('form button')
+      let requestExists = false;
+
+      form.addEventListener('submit', function() {
+        if (!requestExists) {
+          requestExists = true
+          button.setAttribute('disabled', 1)
+        }
+      })
+    </script>
+  </footer>
+</body>
+
+</html>

--- a/php/logout.php
+++ b/php/logout.php
@@ -1,0 +1,12 @@
+<?php
+require_once(dirname(__FILE__) . '/resources.php');
+
+session_start();
+
+session_unset();
+
+session_destroy();
+
+header('Location: ' . $_ENV['ROOT_DIR'] . '/login');
+
+?>

--- a/php/messages.php
+++ b/php/messages.php
@@ -1,6 +1,13 @@
 <?php
-require_once(dirname(__FILE__) . "/_general.php");
+session_start();
+
 require_once(dirname(__FILE__) . "/resources.php");
+
+if (!isset($_SESSION['user'])) {
+    header('Location:' . $_ENV['ROOT_DIR'] . '/login' );
+}
+
+require_once(dirname(__FILE__) . "/_general.php");
 require_once(dirname(__FILE__) . "/fun/messages.php");
 
 $actual_website = "messages";

--- a/php/reclaims.php
+++ b/php/reclaims.php
@@ -1,5 +1,12 @@
 <?php
+session_start();
+
 require_once(dirname(__FILE__) . "/resources.php");
+
+if (!isset($_SESSION['user'])) {
+    header('Location:' . $_ENV['ROOT_DIR'] . '/login' );
+}
+
 require_once(dirname(__FILE__) . "/_general.php");
 require_once(dirname(__FILE__) . "/fun/reclaims.php");
 

--- a/php/resources.php
+++ b/php/resources.php
@@ -28,6 +28,7 @@ $__RECLAIMS = $_ENV['DB_TB_RECLAIMS'];
 $__SALES = $_ENV['DB_TB_SALES'];
 $__MESSAGES = $_ENV['DB_TB_MESSAGES'];
 $__VENDORS = $_ENV['DB_TB_VENDORS'];
+$__USERS = $_ENV['DB_TB_USERS'];
 
 function get_date_diff(string $str) 
 {

--- a/php/router.php
+++ b/php/router.php
@@ -1,4 +1,6 @@
 <?php
+session_start();
+
 require __DIR__ . "/resources.php";
 
 use Slim\Factory\AppFactory;
@@ -347,6 +349,36 @@ $app->post("/v1/accounts", function (Request $request, Response $response) {
 
   $response->getBody()->write("Account created.");
   return $response->withHeader('Content-Type', 'text/text')->withStatus(201);
+});
+
+$app->post("/v1/users", function (Request $request, Response $response) {
+  global $main_conn, $__USERS;
+
+  $body = $request->getParsedBody();
+  $username = clean_txt($body['Username']);
+  $password = clean_txt($body['Password']);
+
+  $stmp = $main_conn->prepare("SELECT * FROM `$__USERS` WHERE `USERNAME` = ?");
+  $stmp->bind_param("s", $username);
+  $stmp->execute();
+  $results = $stmp->get_result()->fetch_assoc();
+
+  if (!$main_conn->affected_rows) {
+    return $response->withHeader('Location', $_ENV['ROOT_DIR'] . '/login?error_banner=1')->withStatus(302);
+  }
+
+  $hashed_password = $results['password'];
+
+  if (!password_verify($password, $hashed_password)) {
+    return $response->withHeader('Location', $_ENV['ROOT_DIR'] . '/login?error_banner=1')->withStatus(302);
+  }
+
+  $_SESSION['user'] = $results['ID'];
+  $_SESSION['username'] = $results['username'];
+  $_SESSION['priviledges'] = $results['access_level'];
+  $_SESSION['loggedInOn'] = date('Y m d H:i:s');
+
+  return $response->withHeader('Location', $_ENV['ROOT_DIR'] . '/accounts')->withStatus(302);
 });
 
 $app->post("/v1/subsites", function (Request $request, Response $response) {

--- a/php/sales.php
+++ b/php/sales.php
@@ -1,5 +1,11 @@
 <?php
+session_start();
+
 require_once(dirname(__FILE__) . "/resources.php");
+
+if (!isset($_SESSION['user'])) {
+    header('Location:' . $_ENV['ROOT_DIR'] . '/login' );
+}
 
 $actual_website = "sales";
 $actual_site = $_GET['website'] ?? false;

--- a/php/vendors.php
+++ b/php/vendors.php
@@ -1,5 +1,12 @@
 <?php
+session_start();
+
 include(dirname(__FILE__) . '/resources.php');
+
+if (!isset($_SESSION['user'])) {
+    header('Location:' . $_ENV['ROOT_DIR'] . '/login' );
+}
+
 include (dirname(__FILE__) .'/_general.php');
 
 $actual_website = "vendors";

--- a/php/websites.php
+++ b/php/websites.php
@@ -1,5 +1,12 @@
 <?php
+session_start();
+
 require_once(dirname(__FILE__) . '/resources.php');
+
+if (!isset($_SESSION['user'])) {
+    header('Location:' . $_ENV['ROOT_DIR'] . '/login' );
+}
+
 require_once(dirname(__FILE__) . '/_general.php');
 require_once(dirname(__FILE__) . '/fun/websites.php');
 


### PR DESCRIPTION
This PR implements the use of PHP's session cookies to protect certain pages from being accessed by unauthorized users.

## Important Changes
- `php/`
  - `login.php` - New file
  - `logout.php` - New File
  - `header.php` - Add link to logout page
  - `router.php` - Set up new route used for authorizing users
  - `resources.php` - Add new variable `$__USERS` 
- `.env.sample` - Add new environment variable: `DB_TB_USERS`

The following list of pages are now reserved for logged in user only:
 - `websites.php`
 - `accounts.php`
 - `messages.php`
 - `reclaims.php`
 - `vendors.php`
 - `sales.php`