### PR TITLE
Change tests asynchronous code

### DIFF
--- a/__test__/ModalPictureInput.test.js
+++ b/__test__/ModalPictureInput.test.js
@@ -21,19 +21,17 @@ describe("initial behavior", () => {
   })
 
   test("the existence of the main node", async () => {
-    await customElements.whenDefined("modal-picture-input").then(() => {
-      const node = pictureInput.root
+    await customElements.whenDefined("modal-picture-input")
+    const node = pictureInput.root
 
-      expect(node).toBeDefined()
-    })
+    expect(node).toBeDefined()
   })
 
   test("initial values", async () => {
-    await customElements.whenDefined("modal-picture-input").then(() => {
-      expect(pictureInput.scale).toBe(1)
-      expect(pictureInput.coords).toBeNull()
-      expect(pictureInput.file).toBeNull()
-    })
+    await customElements.whenDefined("modal-picture-input")
+    expect(pictureInput.scale).toBe(1)
+    expect(pictureInput.coords).toBeNull()
+    expect(pictureInput.file).toBeNull()
   })
 })
 
@@ -52,54 +50,51 @@ describe("file uploading", () => {
   })
 
   test("file upload", async () => {
-    await customElements.whenDefined("modal-picture-input").then(() => {
-      const mockPicture = new File([], "TEST.jpeg", { type: "image/jpeg" })
+    await customElements.whenDefined("modal-picture-input")
+    const mockPicture = new File([], "TEST.jpeg", { type: "image/jpeg" })
 
-      fireEvent.change(pictureInput.fileInputNode, {
-        target: {
-          files: [mockPicture],
-        },
-      })
-
-      expect(pictureInput.file).toBe(mockPicture)
+    fireEvent.change(pictureInput.fileInputNode, {
+      target: {
+        files: [mockPicture]
+      }
     })
+
+    expect(pictureInput.file).toBe(mockPicture)
   })
 
   it("prevents upload of an invalid file format", async () => {
-    await customElements.whenDefined("modal-picture-input").then(() => {
-      const mockPicture = new File([], "TEST.png", { type: "image/png" })
+    await customElements.whenDefined("modal-picture-input")
+    const mockPicture = new File([], "TEST.png", { type: "image/png" })
 
-      fireEvent.change(pictureInput.fileInputNode, {
-        target: {
-          files: [mockPicture],
-        },
-      })
-
-      expect(pictureInput.file).toBeNull()
+    fireEvent.change(pictureInput.fileInputNode, {
+      target: {
+        files: [mockPicture]
+      }
     })
+
+    expect(pictureInput.file).toBeNull()
   })
 
   it.skip("prevents upload of an overly heavy file", async () => {
-    await customElements.whenDefined("modal-picture-input").then(() => {
-      let data = ""
-      const size = 3 * 1024 * 1024
+    await customElements.whenDefined("modal-picture-input")
+    let data = ""
+    const size = 3 * 1024 * 1024
 
-      for (let i = 0; i < size; i++) {
-        data += "0"
-      }
+    for (let i = 0; i < size; i++) {
+      data += "0"
+    }
 
-      const mockPicture = new Blob([data], {
-        type: "image/jpeg",
-      })
-
-      fireEvent.change(pictureInput.fileInputNode, {
-        target: {
-          files: [mockPicture],
-        },
-      })
-
-      expect(pictureInput.file).toBeNull()
+    const mockPicture = new Blob([data], {
+      type: "image/jpeg"
     })
+
+    fireEvent.change(pictureInput.fileInputNode, {
+      target: {
+        files: [mockPicture]
+      }
+    })
+
+    expect(pictureInput.file).toBeNull()
   })
 })
 
@@ -125,8 +120,8 @@ describe("picture transformations", () => {
 
     fireEvent.change(pictureInput.fileInputNode, {
       target: {
-        files: [mockedPicture],
-      },
+        files: [mockedPicture]
+      }
     })
   })
 
@@ -135,107 +130,101 @@ describe("picture transformations", () => {
   })
 
   it("zooms in the image", async () => {
-    await customElements.whenDefined("modal-picture-input").then(() => {
-      let actualScale = null
+    await customElements.whenDefined("modal-picture-input")
+    let actualScale = null
 
-      for (let i = 0; i < 3; i++) {
-        fireEvent.click(pictureInput.controls.zoomIn)
-      }
+    for (let i = 0; i < 3; i++) {
+      fireEvent.click(pictureInput.controls.zoomIn)
+    }
 
-      actualScale = pictureInput.zoom.getScale()
+    actualScale = pictureInput.zoom.getScale()
 
-      expect(actualScale).toBe("1.3")
-    })
+    expect(actualScale).toBe("1.3")
   })
 
   it("zooms in the image (max)", async () => {
-    await customElements.whenDefined("modal-picture-input").then(() => {
-      let actualScale = null
-      const tooManyTimes = 15
-      const maxScale = "2.0"
+    await customElements.whenDefined("modal-picture-input")
+    let actualScale = null
+    const tooManyTimes = 15
+    const maxScale = "2.0"
 
-      for (let i = 0; i < tooManyTimes; i++) {
-        fireEvent.click(pictureInput.controls.zoomIn)
-      }
+    for (let i = 0; i < tooManyTimes; i++) {
+      fireEvent.click(pictureInput.controls.zoomIn)
+    }
 
-      actualScale = pictureInput.zoom.getScale()
+    actualScale = pictureInput.zoom.getScale()
 
-      expect(actualScale).toBe(maxScale)
-    })
+    expect(actualScale).toBe(maxScale)
   })
 
   it("zooms in the image (random 1-9 number)", async () => {
-    await customElements.whenDefined("modal-picture-input").then(() => {
-      let actualScale = null
-      const randomNumber = Number.parseInt(Math.random() * 10)
-      const expectedScale = "1" + "." + randomNumber
+    await customElements.whenDefined("modal-picture-input")
+    let actualScale = null
+    const randomNumber = Number.parseInt(Math.random() * 10)
+    const expectedScale = "1" + "." + randomNumber
 
-      for (let i = 0; i < randomNumber; i++) {
-        fireEvent.click(pictureInput.controls.zoomIn)
-      }
+    for (let i = 0; i < randomNumber; i++) {
+      fireEvent.click(pictureInput.controls.zoomIn)
+    }
 
-      actualScale = pictureInput.zoom.getScale()
+    actualScale = pictureInput.zoom.getScale()
 
-      expect(actualScale).toBe(expectedScale)
-    })
+    expect(actualScale).toBe(expectedScale)
   })
 
   it("zooms out the image", async () => {
-    await customElements.whenDefined("modal-picture-input").then(() => {
-      let actualScale = null
+    await customElements.whenDefined("modal-picture-input")
+    let actualScale = null
 
-      for (let i = 0; i < 5; i++) {
-        fireEvent.click(pictureInput.controls.zoomIn)
-      }
+    for (let i = 0; i < 5; i++) {
+      fireEvent.click(pictureInput.controls.zoomIn)
+    }
 
-      for (let i = 0; i < 5; i++) {
-        fireEvent.click(pictureInput.controls.zoomOut)
-      }
+    for (let i = 0; i < 5; i++) {
+      fireEvent.click(pictureInput.controls.zoomOut)
+    }
 
-      actualScale = pictureInput.zoom.getScale()
+    actualScale = pictureInput.zoom.getScale()
 
-      expect(actualScale).toBe("1.0")
-    })
+    expect(actualScale).toBe("1.0")
   })
 
   it("zooms out the image (max)", async () => {
-    await customElements.whenDefined("modal-picture-input").then(() => {
-      let actualScale = null
-      const tooManyTimes = 15
-      const minScale = "1.0"
+    await customElements.whenDefined("modal-picture-input")
+    let actualScale = null
+    const tooManyTimes = 15
+    const minScale = "1.0"
 
-      for (let i = 0; i < 5; i++) {
-        fireEvent.click(pictureInput.controls.zoomIn)
-      }
+    for (let i = 0; i < 5; i++) {
+      fireEvent.click(pictureInput.controls.zoomIn)
+    }
 
-      for (let i = 0; i < tooManyTimes; i++) {
-        fireEvent.click(pictureInput.controls.zoomOut)
-      }
+    for (let i = 0; i < tooManyTimes; i++) {
+      fireEvent.click(pictureInput.controls.zoomOut)
+    }
 
-      actualScale = pictureInput.zoom.getScale()
+    actualScale = pictureInput.zoom.getScale()
 
-      expect(actualScale).toBe(minScale)
-    })
+    expect(actualScale).toBe(minScale)
   })
 
   it("zooms out the image (random 1-9 number)", async () => {
-    await customElements.whenDefined("modal-picture-input").then(() => {
-      let actualScale = null
-      const randomNumber = Number.parseInt(Math.random() * 8) + 1
-      const expectedScale = "1" + "." + (10 - randomNumber)
+    await customElements.whenDefined("modal-picture-input")
+    let actualScale = null
+    const randomNumber = Number.parseInt(Math.random() * 8) + 1
+    const expectedScale = "1" + "." + (10 - randomNumber)
 
-      for (let i = 0; i < 10; i++) {
-        fireEvent.click(pictureInput.controls.zoomIn)
-      }
+    for (let i = 0; i < 10; i++) {
+      fireEvent.click(pictureInput.controls.zoomIn)
+    }
 
-      for (let i = 0; i < randomNumber; i++) {
-        fireEvent.click(pictureInput.controls.zoomOut)
-      }
+    for (let i = 0; i < randomNumber; i++) {
+      fireEvent.click(pictureInput.controls.zoomOut)
+    }
 
-      actualScale = pictureInput.zoom.getScale()
+    actualScale = pictureInput.zoom.getScale()
 
-      expect(actualScale).toBe(expectedScale)
-    })
+    expect(actualScale).toBe(expectedScale)
   })
 })
 
@@ -254,20 +243,19 @@ describe("flushing", () => {
   })
 
   it("flushes out the file and settings", async () => {
-    await customElements.whenDefined("modal-picture-input").then(() => {
-      const mockPicture = new File([], "TEST.jpeg", { type: "image/jpeg" })
+    await customElements.whenDefined("modal-picture-input")
+    const mockPicture = new File([], "TEST.jpeg", { type: "image/jpeg" })
 
-      fireEvent.change(pictureInput.fileInputNode, {
-        target: {
-          files: [mockPicture],
-        },
-      })
-
-      fireEvent.click(pictureInput.controls.remove)
-
-      expect(pictureInput.file).toBeNull()
-      expect(pictureInput.coords).toBeNull()
-      expect(pictureInput.zoom.getScale()).toBe("1.0")
+    fireEvent.change(pictureInput.fileInputNode, {
+      target: {
+        files: [mockPicture]
+      }
     })
+
+    fireEvent.click(pictureInput.controls.remove)
+
+    expect(pictureInput.file).toBeNull()
+    expect(pictureInput.coords).toBeNull()
+    expect(pictureInput.zoom.getScale()).toBe("1.0")
   })
 })

--- a/__test__/ModalPriceInput.test.js
+++ b/__test__/ModalPriceInput.test.js
@@ -19,93 +19,93 @@ describe("basic typing functionality", () => {
     parent.innerHTML = ""
   })
 
-  test("typing of simple numbers", () => {
-    customElements.whenDefined("modal-price-input").then(() => {
-      const validInput = "123"
-      const expectedValue = "$123.00 MXN/MONTH"
+  test("typing of simple numbers", async () => {
+    const validInput = "123"
+    const expectedValue = "$123.00 MXN/MONTH"
 
-      for (let i = 0; i < validInput.length; i++) {
-        const char = validInput[i]
+    await customElements.whenDefined("modal-price-input")
 
-        fireEvent.keyDown(priceInput.field, {
-          key: char,
-          charCode: char.charCodeAt(0),
-        })
-      }
+    for (let i = 0; i < validInput.length; i++) {
+      const char = validInput[i]
 
-      expect(priceInput.value).toBe(expectedValue)
-    })
+      fireEvent.keyDown(priceInput.field, {
+        key: char,
+        charCode: char.charCodeAt(0)
+      })
+    }
+
+    expect(priceInput.value).toBe(expectedValue)
   })
 
-  test("typing of invalid characters", () => {
-    customElements.whenDefined("modal-price-input").then(() => {
-      const invalidInput = "ASD$123,,~@#&*"
-      const expectedValue = "$123.00 MXN/MONTH"
+  test("typing of invalid characters", async () => {
+    const invalidInput = "ASD$123,,~@#&*"
+    const expectedValue = "$123.00 MXN/MONTH"
 
-      for (let i = 0; i < invalidInput.length; i++) {
-        const char = invalidInput[i]
+    await customElements.whenDefined("modal-price-input")
 
-        fireEvent.keyDown(priceInput.field, {
-          key: char,
-          charCode: char.charCodeAt(0),
-        })
-      }
+    for (let i = 0; i < invalidInput.length; i++) {
+      const char = invalidInput[i]
 
-      expect(priceInput.value).toBe(expectedValue)
-    })
+      fireEvent.keyDown(priceInput.field, {
+        key: char,
+        charCode: char.charCodeAt(0)
+      })
+    }
+
+    expect(priceInput.value).toBe(expectedValue)
   })
 
-  test("typing a valid number then remove a few characters", () => {
-    customElements.whenDefined("modal-price-input").then(() => {
-      const initialInput = "890"
-      const lastInput = "75"
-      const expectedValue = "$875.00 MXN/MONTH"
+  test("typing a valid number then remove a few characters", async () => {
+    const initialInput = "890"
+    const lastInput = "75"
+    const expectedValue = "$875.00 MXN/MONTH"
 
-      for (let i = 0; i < initialInput.length; i++) {
-        const char = initialInput[i]
+    await customElements.whenDefined("modal-price-input")
 
-        fireEvent.keyDown(priceInput.field, {
-          key: char,
-          charCode: char.charCodeAt(0),
-        })
-      }
+    for (let i = 0; i < initialInput.length; i++) {
+      const char = initialInput[i]
 
-      for (let i = 0; i < 2; i++) {
-        fireEvent.keyDown(priceInput.field, {
-          key: "Backspace",
-          charCode: 0,
-        })
-      }
+      fireEvent.keyDown(priceInput.field, {
+        key: char,
+        charCode: char.charCodeAt(0)
+      })
+    }
 
-      for (let i = 0; i < lastInput.length; i++) {
-        const char = lastInput[i]
+    for (let i = 0; i < 2; i++) {
+      fireEvent.keyDown(priceInput.field, {
+        key: "Backspace",
+        charCode: 0
+      })
+    }
 
-        fireEvent.keyDown(priceInput.field, {
-          key: char,
-          charCode: char.charCodeAt(0),
-        })
-      }
+    for (let i = 0; i < lastInput.length; i++) {
+      const char = lastInput[i]
 
-      expect(priceInput.value).toBe(expectedValue)
-    })
+      fireEvent.keyDown(priceInput.field, {
+        key: char,
+        charCode: char.charCodeAt(0)
+      })
+    }
+
+    expect(priceInput.value).toBe(expectedValue)
   })
 
-  test("typing decimal numbers", () => {
-    customElements.whenDefined("modal-price-input").then(() => {
-      const invalidInput = "123.45"
-      const expectedValue = "$123.45 MXN/MONTH"
+  test("typing decimal numbers", async () => {
+    const invalidInput = "123.45"
+    const expectedValue = "$123.45 MXN/MONTH"
 
-      for (let i = 0; i < invalidInput.length; i++) {
-        const char = invalidInput[i]
+    await customElements.whenDefined("modal-price-input")
 
-        fireEvent.keyDown(priceInput.field, {
-          key: char,
-          charCode: char.charCodeAt(0),
-        })
-      }
+    for (let i = 0; i < invalidInput.length; i++) {
+      const char = invalidInput[i]
 
-      expect(priceInput.value).toBe(expectedValue)
-    })
+      fireEvent.keyDown(priceInput.field, {
+        key: char,
+        charCode: char.charCodeAt(0)
+      })
+    }
+
+    expect(priceInput.value).toBe(expectedValue)
   })
 })
 
@@ -123,88 +123,88 @@ describe("edge-cases typing functionality", () => {
     parent.innerHTML = ""
   })
 
-  test("leading zeroes and then a normal number", () => {
-    customElements.whenDefined("modal-price-input").then(() => {
-      const leadingZeroes = "000"
-      const validInput = "123"
-      const expectedValue = "$123.00 MXN/MONTH"
+  test("leading zeroes and then a normal number", async () => {
+    const leadingZeroes = "000"
+    const validInput = "123"
+    const expectedValue = "$123.00 MXN/MONTH"
 
-      for (let i = 0; i < leadingZeroes.length; i++) {
-        const char = leadingZeroes[i]
+    await customElements.whenDefined("modal-price-input")
 
-        fireEvent.keyDown(priceInput.field, {
-          key: char,
-          charCode: char.charCodeAt(0),
-        })
-      }
-
-      for (let i = 0; i < validInput.length; i++) {
-        const char = validInput[i]
-
-        fireEvent.keyDown(priceInput.field, {
-          key: char,
-          charCode: char.charCodeAt(0),
-        })
-      }
-
-      expect(priceInput.value).toBe(expectedValue)
-    })
-  })
-
-  test("typing when caret is off position", () => {
-    customElements.whenDefined("modal-price-input").then(() => {
-      const initialValue = "1"
-      const validInput = "23"
-      const expectedValue = "$123.00 MXN/MONTH"
-
-      priceInput.value = initialValue
-      fireEvent.focus(priceInput.field)
-      priceInput.field.setSelectionRange(
-        priceInput.value.length,
-        priceInput.value.length
-      )
-
-      for (let i = 0; i < validInput.length; i++) {
-        const char = validInput[i]
-
-        fireEvent.keyDown(priceInput.field, {
-          key: char,
-          charCode: char.charCodeAt(0),
-        })
-      }
-
-      expect(priceInput.value).toBe(expectedValue)
-    })
-  })
-
-  test("typing when caret is on decimal position", () => {
-    customElements.whenDefined("modal-price-input").then(() => {
-      let decimalPointPos
-      const initialValue = "123"
-      const decimalValue = "45"
-      const expectedValue = "$123.45 MXN/MONTH"
-
-      priceInput.value = initialValue
-      decimalPointPos = priceInput.field.value.indexOf(".")
-
-      fireEvent.focus(priceInput.field)
-      priceInput.field.setSelectionRange(decimalPointPos, decimalPointPos)
+    for (let i = 0; i < leadingZeroes.length; i++) {
+      const char = leadingZeroes[i]
 
       fireEvent.keyDown(priceInput.field, {
-        key: ".",
-        charCode: ".".charCodeAt(0),
+        key: char,
+        charCode: char.charCodeAt(0)
       })
+    }
 
-      for (let i = 0; i < decimalValue.length; i++) {
-        const char = decimalValue[i]
+    for (let i = 0; i < validInput.length; i++) {
+      const char = validInput[i]
 
-        fireEvent.keyDown(priceInput.field, {
-          key: char,
-          charCode: char.charCodeAt(0),
-        })
-      }
+      fireEvent.keyDown(priceInput.field, {
+        key: char,
+        charCode: char.charCodeAt(0)
+      })
+    }
 
-      expect(priceInput.value).toBe(expectedValue)
+    expect(priceInput.value).toBe(expectedValue)
+  })
+
+  test("typing when caret is off position", async () => {
+    const initialValue = "1"
+    const validInput = "23"
+    const expectedValue = "$123.00 MXN/MONTH"
+
+    await customElements.whenDefined("modal-price-input")
+
+    priceInput.value = initialValue
+    fireEvent.focus(priceInput.field)
+    priceInput.field.setSelectionRange(
+      priceInput.value.length,
+      priceInput.value.length
+    )
+
+    for (let i = 0; i < validInput.length; i++) {
+      const char = validInput[i]
+
+      fireEvent.keyDown(priceInput.field, {
+        key: char,
+        charCode: char.charCodeAt(0)
+      })
+    }
+
+    expect(priceInput.value).toBe(expectedValue)
+  })
+
+  test("typing when caret is on decimal position", async () => {
+    let decimalPointPos
+    const initialValue = "123"
+    const decimalValue = "45"
+    const expectedValue = "$123.45 MXN/MONTH"
+
+    await customElements.whenDefined("modal-price-input")
+
+    priceInput.value = initialValue
+    decimalPointPos = priceInput.field.value.indexOf(".")
+
+    fireEvent.focus(priceInput.field)
+    priceInput.field.setSelectionRange(decimalPointPos, decimalPointPos)
+
+    fireEvent.keyDown(priceInput.field, {
+      key: ".",
+      charCode: ".".charCodeAt(0)
     })
+
+    for (let i = 0; i < decimalValue.length; i++) {
+      const char = decimalValue[i]
+
+      fireEvent.keyDown(priceInput.field, {
+        key: char,
+        charCode: char.charCodeAt(0)
+      })
+    }
+
+    expect(priceInput.value).toBe(expectedValue)
   })
 })

--- a/__test__/ModalTextInput.test.js
+++ b/__test__/ModalTextInput.test.js
@@ -23,30 +23,27 @@ describe("initial behavior", () => {
     parent.innerHTML = ""
   })
 
-  it("sets correct placeholder string", () => {
-    customElements.whenDefined("modal-text-input").then(() => {
-      const placeholder = textInput.field.getAttribute("placeholder")
+  it("sets correct placeholder string", async () => {
+    await customElements.whenDefined("modal-text-input")
+    const placeholder = textInput.field.getAttribute("placeholder")
 
-      expect(placeholder).toBe(placeholderText)
-    })
+    expect(placeholder).toBe(placeholderText)
   })
 
-  it("sets correct field's name", () => {
-    customElements.whenDefined("modal-text-input").then(() => {
-      const fieldName = textInput.field.getAttribute("name")
+  it("sets correct field's name", async () => {
+    await customElements.whenDefined("modal-text-input")
+    const fieldName = textInput.field.getAttribute("name")
 
-      expect(fieldName).toBe(textFieldName)
-    })
+    expect(fieldName).toBe(textFieldName)
   })
 
-  it("sets value correctly", () => {
-    customElements.whenDefined("modal-text-input").then(() => {
-      const initialValue = "DEFAULT"
+  it("sets value correctly", async () => {
+    const initialValue = "DEFAULT"
+    await customElements.whenDefined("modal-text-input")
 
-      textInput.value = initialValue
+    textInput.value = initialValue
 
-      expect(textInput.field.value).toBe(initialValue)
-    })
+    expect(textInput.field.value).toBe(initialValue)
   })
 })
 
@@ -67,45 +64,42 @@ describe("default functionality", () => {
   test("typing of a valid string", async () => {
     const validString = "TEST"
 
-    await customElements.whenDefined("modal-text-input").then(async () => {
-      await userEvent.type(textInput.field, validString, {
-        delay: 25,
-      })
-
-      expect(textInput.field.value).toBe(validString)
+    await customElements.whenDefined("modal-text-input")
+    await userEvent.type(textInput.field, validString, {
+      delay: 25
     })
+
+    expect(textInput.field.value).toBe(validString)
   })
 
   test("typing of valid keys", async () => {
     const validString = "TEST"
 
-    await customElements.whenDefined("modal-text-input").then(async () => {
-      await userEvent.type(textInput.field, validString, {
-        delay: 25,
-      })
-
-      // trigger three keystrokes of Backspace
-      await userEvent.type(textInput.field, "{Backspace}")
-      await userEvent.type(textInput.field, "{Backspace}")
-      await userEvent.type(textInput.field, "{Backspace}")
-
-      expect(textInput.field.value).toBe(
-        validString.substring(0, validString.length - 3)
-      )
+    await customElements.whenDefined("modal-text-input")
+    await userEvent.type(textInput.field, validString, {
+      delay: 25
     })
+
+    // trigger three keystrokes of Backspace
+    await userEvent.type(textInput.field, "{Backspace}")
+    await userEvent.type(textInput.field, "{Backspace}")
+    await userEvent.type(textInput.field, "{Backspace}")
+
+    expect(textInput.field.value).toBe(
+      validString.substring(0, validString.length - 3)
+    )
   })
 
   test("typing of invalid keys", async () => {
     const invalidString = "TE3ST STR!NG@"
     const finalString = "TESTSTRNG"
 
-    await customElements.whenDefined("modal-text-input").then(async () => {
-      await userEvent.type(textInput.field, invalidString, {
-        delay: 25,
-      })
-
-      expect(textInput.field.value).toBe(finalString)
+    await customElements.whenDefined("modal-text-input")
+    await userEvent.type(textInput.field, invalidString, {
+      delay: 25
     })
+
+    expect(textInput.field.value).toBe(finalString)
   })
 })
 
@@ -125,15 +119,15 @@ describe("custom functionality", () => {
 
   it("sets custom accepted keys", async () => {
     const string = "TEST $TRING@"
-    await customElements.whenDefined("modal-text-input").then(async () => {
-      const validKeys = /\s|[a-z]|@|\$|Backspace/i
+    const validKeys = /\s|[a-z]|@|\$|Backspace/i
 
-      textInput.setAllowedKeys(validKeys)
+    await customElements.whenDefined("modal-text-input")
 
-      await userEvent.type(textInput.field, string)
+    textInput.setAllowedKeys(validKeys)
 
-      expect(textInput.field.value).toBe(string)
-    })
+    await userEvent.type(textInput.field, string)
+
+    expect(textInput.field.value).toBe(string)
   })
 
   it("sets a custom validation Regex", async () => {
@@ -141,21 +135,20 @@ describe("custom functionality", () => {
     const validString = "TEST"
     const invalidString = "LONGSTRING"
 
-    await customElements.whenDefined("modal-text-input").then(async () => {
-      textInput.setValidationRegex(validationRegex)
+    await customElements.whenDefined("modal-text-input")
+    textInput.setValidationRegex(validationRegex)
 
-      await userEvent.type(textInput.field, invalidString, {})
-      await userEvent.tab()
+    await userEvent.type(textInput.field, invalidString, {})
+    await userEvent.tab()
 
-      expect(textInput.field.value).toBe("")
+    expect(textInput.field.value).toBe("")
 
-      // get rid of existing previous string
-      for await (let i of Array.from({ length: invalidString.length }))
-        await userEvent.type(textInput.field, "{Backspace}")
+    // get rid of existing previous string
+    for await (let i of Array.from({ length: invalidString.length }))
+      await userEvent.type(textInput.field, "{Backspace}")
 
-      await userEvent.type(textInput.field, validString)
+    await userEvent.type(textInput.field, validString)
 
-      expect(textInput.field.value).toBe(validString)
-    })
+    expect(textInput.field.value).toBe(validString)
   })
 })

--- a/__test__/ModalURLInput.test.js
+++ b/__test__/ModalURLInput.test.js
@@ -23,62 +23,59 @@ describe("functionality", () => {
   test("typing of a valid string", async () => {
     const validString = "testwebsite.com"
 
-    await customElements.whenDefined("modal-url-input").then(async () => {
-      await userEvent.type(url_input.field, validString, {
-        delay: 25,
-      })
+    await customElements.whenDefined("modal-url-input")
 
-      expect(url_input.field.value).toBe(validString)
+    await userEvent.type(url_input.field, validString, {
+      delay: 25
     })
+
+    expect(url_input.field.value).toBe(validString)
   })
 
   test("typing invalid characters", async () => {
     const invalidString = "!test#website^&.com)"
     const expectedString = "testwebsite.com"
 
-    await customElements.whenDefined("modal-url-input").then(async () => {
-      await userEvent.type(url_input.field, invalidString, {
-        delay: 25,
-      })
-      expect(url_input.field.value).toBe(expectedString)
+    await customElements.whenDefined("modal-url-input")
+    await userEvent.type(url_input.field, invalidString, {
+      delay: 25
     })
+
+    expect(url_input.field.value).toBe(expectedString)
   })
 
   it("prevents pasting values", () => {
-    customElements.whenDefined("modal-url-input").then(() => {
-      let hasBeenPasted = false
-
-      url_input.field.addEventListener("paste", () => {
-        hasBeenPasted = true
-      })
-
-      fireEvent.keyDown(url_input.field, {
-        key: "v",
-        code: "keyV",
-        ctrlKey: true,
-      })
-
-      fireEvent.paste(url_input.field, {
-        clipboardData: {
-          getData: () => "PASTED VALUE",
-        },
-      })
-
-      expect(hasBeenPasted).toBe(true)
-      expect(url_input.value).toBe("")
+    let hasBeenPasted = false
+    customElements.whenDefined("modal-url-input")
+    url_input.field.addEventListener("paste", () => {
+      hasBeenPasted = true
     })
+
+    fireEvent.keyDown(url_input.field, {
+      key: "v",
+      code: "keyV",
+      ctrlKey: true
+    })
+
+    fireEvent.paste(url_input.field, {
+      clipboardData: {
+        getData: () => "PASTED VALUE"
+      }
+    })
+
+    expect(hasBeenPasted).toBe(true)
+    expect(url_input.value).toBe("")
   })
 
   it("whipes out invalid strings", async () => {
     const invalidString = "teststring.c"
-    await customElements.whenDefined("modal-url-input").then(async () => {
-      await userEvent.type(url_input.field, invalidString, {
-        delay: 25,
-      })
-
-      await userEvent.tab() // Trigger focusout event
-
-      expect(url_input.field.value).toBe("")
+    await customElements.whenDefined("modal-url-input")
+    await userEvent.type(url_input.field, invalidString, {
+      delay: 25
     })
+
+    await userEvent.tab() // Trigger focusout event
+
+    expect(url_input.field.value).toBe("")
   })
 })

--- a/__test__/QuantityInput.test.js
+++ b/__test__/QuantityInput.test.js
@@ -18,11 +18,10 @@ describe("initial behavior", () => {
     parent.innerHTML = ""
   })
 
-  test("correct initial value", () => {
-    customElements.whenDefined("quantity-input").then(() => {
-      expect(quantityInput.numberLabel.textContent).toBe("0")
-      expect(quantityInput.value).toBe(0)
-    })
+  test("correct initial value", async () => {
+    await customElements.whenDefined("quantity-input")
+    expect(quantityInput.numberLabel.textContent).toBe("0")
+    expect(quantityInput.value).toBe(0)
   })
 })
 
@@ -40,60 +39,69 @@ describe("functionality", () => {
     parent.innerHTML = ""
   })
 
-  test("the label increments in value", () => {
-    customElements.whenDefined("quantity-input").then(() => {
+  test("the label increments in value", async () => {
+    await customElements.whenDefined("quantity-input")
+    quantityInput.addUp()
+
+    expect(quantityInput.numberLabel.textContent).toBe("1")
+    expect(quantityInput.value).toBe(1)
+  })
+
+  it("prevents going above the max value", async () => {
+    const maxValue = quantityInput.max.toString()
+
+    await customElements.whenDefined("quantity-input")
+
+    for (let i = 0; i < 15; i++) {
       quantityInput.addUp()
+    }
 
-      expect(quantityInput.numberLabel.textContent).toBe("1")
-      expect(quantityInput.value).toBe(1)
-    })
+    expect(quantityInput.numberLabel.textContent).toBe(maxValue)
+    expect(quantityInput.value).toBe(Number(maxValue))
   })
 
-  it("prevents going above the max value", () => {
-    customElements.whenDefined("quantity-input").then(() => {
-      for (let i = 0; i < 15; i++) {
-        quantityInput.addUp()
-      }
+  it("prevents going below the min value", async () => {
+    const minValue = quantityInput.min.toString()
 
-      const maxValue = quantityInput.max.toString()
-      expect(quantityInput.numberLabel.textContent).toBe(maxValue)
-      expect(quantityInput.value).toBe(Number(maxValue))
-    })
+    await customElements.whenDefined("quantity-input")
+
+    for (let i = 0; i < 15; i++) {
+      quantityInput.subtract()
+    }
+
+    expect(quantityInput.numberLabel.textContent).toBe(minValue)
+    expect(quantityInput.value).toBe(Number(minValue))
   })
 
-  it("prevents going above the min value", () => {
-    customElements.whenDefined("quantity-input").then(() => {
-      for (let i = 0; i < 15; i++) {
-        quantityInput.subtract()
-      }
+  it("prevents setting an initial value that offsets max value", async () => {
+    let quantityLabel
+    const maxValue = 20
+    const initialValue = 50
 
-      const minValue = quantityInput.min.toString()
-      expect(quantityInput.numberLabel.textContent).toBe(minValue)
-      expect(quantityInput.value).toBe(Number(minValue))
-    })
+    await customElements.whenDefined("quantity-input")
+    quantityInput.setMaximum(maxValue)
+    quantityInput.setInitial(initialValue)
+
+    quantityLabel = Number.parseInt(quantityInput.numberLabel.textContent)
+
+    expect(quantityLabel).toBe(0)
+    expect(quantityInput.value).toBe(0)
+
   })
 
-  it("prevents setting an initial value that offsets max value", () => {
-    customElements.whenDefined("quantity-input").then(() => {
-      const initialValue = 50
-      const maxValue = quantityInput.max.toString()
+  it("prevents setting an initial value that offsets min value", async () => {
+    let quantityLabel
+    const initialValue = -20
+    const minValue = -10
 
-      quantityInput.setInitial(initialValue)
+    await customElements.whenDefined("quantity-input")
+    quantityInput.setMinimum(minValue)
+    quantityInput.setInitial(initialValue)
 
-      expect(quantityInput.numberLabel.textContent).toBe(maxValue)
-      expect(quantityInput.value).toBe(Number(maxValue))
-    })
-  })
+    quantityLabel = Number.parseInt(quantityInput.numberLabel.textContent)
 
-  it("prevents setting an initial value that offsets min value", () => {
-    customElements.whenDefined("quantity-input").then(() => {
-      const initialValue = -10
-      const minValue = quantityInput.min.toString()
+    expect(quantityLabel).toBe(0)
+    expect(quantityInput.value).toBe(0)
 
-      quantityInput.setInitial(initialValue)
-
-      expect(quantityInput.numberLabel.textContent).toBe(minValue)
-      expect(quantityInput.value).toBe(Number(minValue))
-    })
   })
 })

--- a/__test__/Select.test.js
+++ b/__test__/Select.test.js
@@ -19,26 +19,21 @@ describe("initial behavior", () => {
     parent.innerHTML = ""
   })
 
-  test("<select-emphasized> main node does exist", () => {
-    customElements
-      .whenDefined("select-emphasized")
-      .then(expect(selectEmphasized.node).toBeDefined())
+  test("<select-emphasized> main node does exist", async () => {
+    await customElements.whenDefined("select-emphasized")
+    expect(selectEmphasized.node).toBeDefined()
   })
 
-  it("has the default styles when no options have been supplied", () => {
-    customElements.whenDefined("select-emphasized").then(() => {
-      const listNode = selectEmphasized.node
-      expect(listNode.classList.contains("selection--options-loading")).toBe(
-        true
-      )
-    })
+  it("has the default styles when no options have been supplied", async () => {
+    await customElements.whenDefined("select-emphasized")
+    const listNode = selectEmphasized.node
+    expect(listNode.classList.contains("selection--options-loading")).toBe(true)
   })
 
-  test("the initial label is set to 'SELECT'", () => {
-    customElements.whenDefined("select-emphasized").then(() => {
-      const label = selectEmphasized.node.label.innerHTML
-      expect(label).toBe("SELECT")
-    })
+  test("the initial label is set to 'SELECT'", async () => {
+    await customElements.whenDefined("select-emphasized")
+    const label = selectEmphasized.node.label.innerHTML
+    expect(label).toBe("SELECT")
   })
 })
 
@@ -48,6 +43,7 @@ describe("basic functionality", () => {
   const optionsList = [
     { SITE_CODE: "TST1", SITE_TITLE: "TESTONE" },
     { SITE_CODE: "TST2", SITE_TITLE: "TESTTWO" },
+    { SITE_CODE: "TST3", SITE_TITLE: "TESTTHR" }
   ]
 
   beforeEach(() => {
@@ -61,63 +57,59 @@ describe("basic functionality", () => {
     parent.innerHTML = ""
   })
 
-  it("changes the initial label", () => {
-    customElements.whenDefined("select-emphasized").then(() => {
-      selectEmphasized.setInitialLabel("TEST")
+  it("changes the initial label", async () => {
+    await customElements.whenDefined("select-emphasized")
+    selectEmphasized.setInitialLabel("TEST")
+    const label = selectEmphasized.node.label
 
-      const label = selectEmphasized.node.label
-      expect(label.innerHTML).toBe("TEST")
-    })
+    expect(label.innerHTML).toBe("TEST")
   })
 
-  it("changes the default option", () => {
-    customElements.whenDefined("select-emphasized").then(() => {
-      selectEmphasized.setOptions(optionsList)
-      selectEmphasized.setDefault("TST2")
+  it("changes the default option", async () => {
+    await customElements.whenDefined("select-emphasized")
+    selectEmphasized.setOptions(optionsList)
+    selectEmphasized.setDefault("TST2")
+    const label = selectEmphasized.node.label.innerHTML
 
-      const label = selectEmphasized.node.label.innerHTML
-      expect(label).toBe("TESTTWO")
-    })
+    expect(label).toBe("TESTTWO")
   })
 
-  it("fails to change the default option (option non-existent)", () => {
-    customElements.whenDefined("select-emphasized").then(() => {
-      selectEmphasized.setOptions(optionsList)
+  it("fails to change the default option (option non-existent)", async () => {
+    await customElements.whenDefined("select-emphasized")
+    selectEmphasized.setOptions(optionsList)
 
-      try {
-        selectEmphasized.setDefault("INVALID")
-      } catch (error) {
-        expect(error).toBeDefined()
-      }
-    })
+    try {
+      selectEmphasized.setDefault("INVALID")
+    } catch (error) {
+      expect(error).toBeDefined()
+    }
   })
 
-  it("loads option list", () => {
-    customElements.whenDefined("select-emphasized").then(() => {
-      selectEmphasized.setOptions(optionsList)
-      expect(selectEmphasized.node.list.children.length).toBe(2)
-    })
+  it("loads option list", async () => {
+    await customElements.whenDefined("select-emphasized")
+    selectEmphasized.setOptions(optionsList)
+
+    expect(selectEmphasized.node.list.children.length).toBe(3)
   })
 
-  it("rejects an invalid option list", () => {
+  it("rejects an invalid option list", async () => {
     const invalidList = [{ SITE_CODE: "TST1" }, { SITE_CODE: "TST2" }]
 
-    customElements.whenDefined("select-emphasized").then(() => {
-      try {
-        selectEmphasized.setOptions(invalidList)
-      } catch (error) {
-        expect(error).toBeDefined()
-      }
-    })
+    await customElements.whenDefined("select-emphasized")
+
+    try {
+      selectEmphasized.setOptions(invalidList)
+    } catch (error) {
+      expect(error).toBeDefined()
+    }
   })
 
-  it("changes the styles when option list supplied", () => {
-    customElements.whenDefined("select-emphasized").then(() => {
-      selectEmphasized.setOptions(optionsList)
+  it("changes the styles when option list supplied", async () => {
+    await customElements.whenDefined("select-emphasized")
+    selectEmphasized.setOptions(optionsList)
 
-      expect(
-        selectEmphasized.node.classList.contains("selection--options-loading")
-      ).toBe(false)
-    })
+    expect(
+      selectEmphasized.node.classList.contains("selection--options-loading")
+    ).toBe(false)
   })
 })

--- a/__test__/SelectVendor.test.js
+++ b/__test__/SelectVendor.test.js
@@ -12,13 +12,13 @@ global.fetch = jest.fn(() =>
       Promise.resolve([
         {
           ID: "TESTA",
-          EMAIL: "jon@doe.gov",
+          EMAIL: "jon@doe.gov"
         },
         {
           ID: "TESTB",
-          EMAIL: "doen@jon.gov",
-        },
-      ]),
+          EMAIL: "doen@jon.gov"
+        }
+      ])
   })
 )
 
@@ -37,10 +37,9 @@ describe("initial behavior", () => {
     parent.innerHTML = ""
   })
 
-  test("<select-vendor> main node exists", () => {
-    customElements
-      .whenDefined("select-vendor")
-      .then(expect(selectVendor.parent).toBeDefined())
+  test("<select-vendor> main node exists", async () => {
+    await customElements.whenDefined("select-vendor")
+    expect(selectVendor.parent).toBeDefined()
   })
 })
 
@@ -59,22 +58,21 @@ describe("functionality", () => {
     parent.innerHTML = ""
   })
 
-  it("fetches vendors", () => {
-    customElements.whenDefined("select-vendor").then(async () => {
-      await selectVendor.fetchVendors("TEST")
+  it("fetches vendors", async () => {
+    await customElements.whenDefined("select-vendor")
+    await selectVendor.fetchVendors("TEST")
 
-      expect(selectVendor.vendorsArray.length).toBe(2)
-    })
+    expect(selectVendor.vendorsArray.length).toBe(2)
   })
 
-  it("fills option list with the fetched values", () => {
-    customElements.whenDefined("select-vendor").then(async () => {
-      await selectVendor.fetchVendors("TEST")
-      selectVendor.fillOptionsList()
+  it("fills option list with the fetched values", async () => {
+    await customElements.whenDefined("select-vendor")
+    await selectVendor.fetchVendors("TEST")
+    selectVendor.fillOptionsList()
 
-      const firstOption =
-        selectVendor.optionsList.childNodes[0].querySelector("span")
-      expect(firstOption.textContent).toBe("@TESTA")
-    })
+    const firstOption =
+      selectVendor.optionsList.childNodes[0].querySelector("span")
+
+    expect(firstOption.textContent).toBe("@TESTA")
   })
 })

--- a/js/classes/QuantityInput.js
+++ b/js/classes/QuantityInput.js
@@ -75,6 +75,8 @@ class QuantityInput extends HTMLElement {
     const parsedInt = Number.parseInt(value)
     if (!Number.isFinite(parsedInt)) return
 
+    if (parsedInt < this.min || parsedInt > this.max) return
+
     this.currentValue = parsedInt
     this.numberLabel.innerHTML = parsedInt
   }


### PR DESCRIPTION
This PR changes the asynchronous code portion of the tests files over `/__test__`. The change is relatively simple: just move the code and the test's assertion out of a promise statement due to them triggering odd errors when an assertion is not met.

## Important Changes
- Move code out of the promise returned by `customElements.whenDefined()` 
- Use `async/await` for a procedural code execution
- Add validation to `<quantity-input>` custom element method