### PR TITLE
Update API URI on Cypress tests

### DIFF
--- a/cypress/e2e/EditAccountModal.cy.js
+++ b/cypress/e2e/EditAccountModal.cy.js
@@ -2,20 +2,24 @@ describe("basic functionality", () => {
   const accountID = "XXX-25A1B2"
 
   beforeEach(() => {
-    cy.intercept("POST", Cypress.env("API_HUB_URI"), (req) => {
-      req.reply({
-        SITE_CODE: "TEST",
-        ACCOUNT_ID: "XXX-25A1B2",
-        ACCOUNT_NICK: "JohnDoe",
-        ACCOUNT_PASS: "superman",
-        PRICE_PAID: "99.99",
-        WARRANTY_BEGINS: "2025-01-01",
-        WARRANTY_ENDS: "2025-01-31",
-        N_SOLD: 0,
-        N_AVAILABLE: 4,
-        SITE_URL: "test.com",
-      })
-    }).as("accountRequest")
+    cy.intercept(
+      "GET",
+      Cypress.env("API_URI") + "/accounts/" + accountID,
+      (req) => {
+        req.reply({
+          SITE_CODE: "TEST",
+          ACCOUNT_ID: "XXX-25A1B2",
+          ACCOUNT_NICK: "JohnDoe",
+          ACCOUNT_PASS: "superman",
+          PRICE_PAID: "99.99",
+          WARRANTY_BEGINS: "2025-01-01",
+          WARRANTY_ENDS: "2025-01-31",
+          N_SOLD: 0,
+          N_AVAILABLE: 4,
+          SITE_URL: "test.com",
+        })
+      }
+    ).as("accountRequest")
 
     cy.visit(Cypress.env("EDITACCOUNTMODAL_MOCKUP_URI"))
     cy.get("edit-account-modal", { timeout: 5000 })
@@ -132,7 +136,9 @@ describe("basic functionality", () => {
   })
 
   it("prevents form submission if there exists no changes on fields", () => {
-    cy.intercept("POST", Cypress.env("API_HUB_URI")).as("submitRequest")
+    cy.intercept("PUT", Cypress.env("API_URI") + "accounts/" + accountID).as(
+      "submitRequest"
+    )
     cy.get("edit-account-modal").then(($modal) => {
       const modal = $modal[0]
       modal.setAttribute("account", accountID)
@@ -164,20 +170,24 @@ describe("how does the modal react to modifications of its initial state", () =>
   const price_mock = "77.77"
 
   beforeEach(() => {
-    cy.intercept("POST", Cypress.env("API_HUB_URI"), (req) => {
-      req.reply({
-        SITE_CODE: "TEST",
-        ACCOUNT_ID: "XXX-25A1B2",
-        ACCOUNT_NICK: "JohnDoe",
-        ACCOUNT_PASS: "superman",
-        PRICE_PAID: "99.99",
-        WARRANTY_BEGINS: "2025-01-01",
-        WARRANTY_ENDS: "2025-01-31",
-        N_SOLD: 0,
-        N_AVAILABLE: 4,
-        SITE_URL: "test.com",
-      })
-    }).as("accountRequest")
+    cy.intercept(
+      "GET",
+      Cypress.env("API_URI") + "/accounts/" + accountID,
+      (req) => {
+        req.reply({
+          SITE_CODE: "TEST",
+          ACCOUNT_ID: "XXX-25A1B2",
+          ACCOUNT_NICK: "JohnDoe",
+          ACCOUNT_PASS: "superman",
+          PRICE_PAID: "99.99",
+          WARRANTY_BEGINS: "2025-01-01",
+          WARRANTY_ENDS: "2025-01-31",
+          N_SOLD: 0,
+          N_AVAILABLE: 4,
+          SITE_URL: "test.com",
+        })
+      }
+    ).as("accountRequest")
 
     cy.visit(Cypress.env("EDITACCOUNTMODAL_MOCKUP_URI"))
     cy.get("edit-account-modal", { timeout: 5000 })

--- a/cypress/e2e/NewAccountModal.cy.js
+++ b/cypress/e2e/NewAccountModal.cy.js
@@ -1,6 +1,6 @@
 describe("basic functionality", () => {
-  before(() => {
-    cy.intercept("POST", Cypress.env("API_HUB_URI"), (req) => {
+  beforeEach(() => {
+    cy.intercept("GET", Cypress.env("API_URI") + "/websites", (req) => {
       req.reply([
         {
           ID: "TEST_A",
@@ -24,9 +24,6 @@ describe("basic functionality", () => {
         },
       ])
     })
-  })
-
-  beforeEach(() => {
     cy.visit(Cypress.env("NEWACCOUNTMODAL_MOCKUP_URI"))
     cy.get("new-account-modal", { timeout: 5000 })
     cy.get("button.open").click().wait(1000)


### PR DESCRIPTION
This PR updates Cypress environment variables so they make use of the new API URI instead of the ancient requests made to `hub.php`.

